### PR TITLE
Adds HostKeyCallback to ssh.ClientConfig

### DIFF
--- a/lib/runner.go
+++ b/lib/runner.go
@@ -82,6 +82,7 @@ func Run(c Config) {
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeysCallback(agentClient.Signers),
 		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
 	connectionsMade := 0


### PR DESCRIPTION
Fix https://github.com/zendesk/punchabunch/issues/2
This is needed since golang/go#19767

Not sure if we are going to maintain this repo.

cc @zendesk/compute 